### PR TITLE
Fix warnings

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -438,7 +438,7 @@ impl Protocol {
     /// ```
     ///
     pub fn initialize_file(&self, source_path: &str) -> Result<(String, String, u32, u32), ProtocolError> {
-        match self.stored_files.lock().unwrap().get(&source_path.clone().to_string()) {
+        match self.stored_files.lock().unwrap().get(&source_path.to_string()) {
             Some((file_name, hash, num_chunks, mode)) => Ok((file_name.to_string(), hash.to_string(), *num_chunks, *mode)),
             None => storage::initialize_file(
                 &self.config.storage_prefix,
@@ -472,7 +472,7 @@ impl Protocol {
 
     /// Initialize a file for transfer
     fn initialize(&self, channel_id: u32, source_path: &Option<String>) -> Result<State, ProtocolError> {
-        let mut new_state = State::Done;
+        let new_state;
 
         if source_path.is_some() {
             let path = std::path::Path::new(source_path.as_ref().unwrap());


### PR DESCRIPTION
An effort to tag and fix an up-to-date versions of `ftp-client` and `file-service` with known compatible revisions of the `file-protocol` dependencies. I would like to look into the fork of `ktra` to get versioned crates of these dependencies published and integrated.

This only has a simple warning fix.